### PR TITLE
fix: change showCaptions from true to false

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -107,7 +107,9 @@ module.exports = {
               // the content container as this plugin uses this as the
               // base for generating different widths of each image.
               maxWidth: 784,
-              showCaptions: true
+              // gatsby-remark-images 3.0.11 will show alt as caption if no caption is provided,
+              // so we set showCaptions to false
+              showCaptions: false
             }
           }
         ]


### PR DESCRIPTION
gatsby-remark-images 3.0.11
(introduced in 7de7ad40f3)
will show alt as caption if no caption is provided,
and filename as caption if no alt/caption is provided.
gatsbyjs/gatsby#14219 fixed the fallback to filename issue,
but still preserves the fallback to alt behaviour.
Thus I set showCaptions to false.
(`alt` is intended for users cannot see the image.
Displaying *alternative* text *alongside* images feels wierd.)

![Screenshot_2019-05-27 6 款热门 macOS 开源应用](https://user-images.githubusercontent.com/114114/58402821-c67adf80-8093-11e9-8e79-7e252b434ece.png)
